### PR TITLE
bitshift seg

### DIFF
--- a/tex-ray/segmentation.py
+++ b/tex-ray/segmentation.py
@@ -289,6 +289,7 @@ def segment_reconstruction(config_dict):
                         tile_size[2] * (k - (tiling[2] - 1) / 2),
                     ]
                 )
+                bit_flags = [5, 3, 2] # Results in 5, 6, 7 after kernel bit xor.
                 for l in range(3):
                     shifted_tri = triangles[l] + shift
                     rotated_tri = rot.apply(shifted_tri)
@@ -302,10 +303,10 @@ def segment_reconstruction(config_dict):
                             gpu_triangles.flatten().astype(cp.float32),
                             cp.int32(num_voxels),
                             cp.float64(voxel_size),
-                            cp.int32(l + 1),
+                            cp.int32(bit_flags[l]),
                             vox,
                         ),
                     )
 
-    vox = vox.reshape(num_voxels, num_voxels, num_voxels)
+    vox = vox.reshape(num_voxels, num_voxels, num_voxels) & 3 # Makes it 1, 2, 3
     return vox.get().astype(np.uint8)


### PR DESCRIPTION
Fixes the segmentation. Previous bug resulted in weft erroneously being assigned 3. I now undestand properly how atomicxor works bitwise. The bitflags + and hack results in matrix 1 weft 2 warp 3 as required.