### PR TITLE
Dev/better ml checkpointing

### DIFF
--- a/textomos/torch_models.py
+++ b/textomos/torch_models.py
@@ -21,10 +21,10 @@ class DoubleConv(nn.Module):
         super().__init__()
         self.double_conv = nn.Sequential(
             nn.Conv3d(in_channels, out_channels, kernel_size=3, padding=1),
-            nn.InstanceNorm3d(out_channels),
+            nn.BatchNorm3d(out_channels),
             nn.ReLU(inplace=True),
             nn.Conv3d(out_channels, out_channels, kernel_size=3, padding=1),
-            nn.InstanceNorm3d(out_channels),
+            nn.BatchNorm3d(out_channels),
             nn.ReLU(inplace=True),
         )
 

--- a/textomos/torch_segmentation.py
+++ b/textomos/torch_segmentation.py
@@ -1429,8 +1429,7 @@ if __name__ == "__main__":
     generator = seed_all(rng_seed)
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
-    #writer = SummaryWriter(flush_secs=1)
-    writer=None
+    writer = SummaryWriter(flush_secs=1)
     end_epoch=num_epochs
     if len(sys.argv) > 1:
         end_epoch = int(sys.argv[1])

--- a/textomos/torch_segmentation.py
+++ b/textomos/torch_segmentation.py
@@ -1429,10 +1429,13 @@ if __name__ == "__main__":
     generator = seed_all(rng_seed)
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     model = model.to(device)
-    writer = SummaryWriter(flush_secs=1)
     end_epoch=num_epochs
     if len(sys.argv) > 1:
         end_epoch = int(sys.argv[1])
+    if len(sys.argv) > 2:
+        writer = SummaryWriter(sys.argv[2],flush_secs=1)
+    else:
+        writer = SummaryWriter(flush_secs=1)
     if train:
         training_set = TextomosDataset3D(
             training_data_path,


### PR DESCRIPTION
This PR adds functionality to the ML training pipeline that enables smarter checkpointing. When running through a batch submission system like SLURM it is now possible to train one epoch at a time and continue at the appropriate learn rate scheduler state when starting at a new epoch from the batch script.